### PR TITLE
jeedomUtils.initTooltips for 4.4

### DIFF
--- a/desktop/modal/advanceConfig.php
+++ b/desktop/modal/advanceConfig.php
@@ -110,7 +110,7 @@ global $JEEDOM_INTERNAL_CONFIG;
 </div>
 
 <script>
-initTooltips($("#div_advanceConfigForm"))
+jeedomUtils.initTooltips($("#div_advanceConfigForm"))
 $('#div_advanceConfigForm').setValues(device, '.deviceAttr');
 $('.bt_advanceConfigSaveDevice').on('click',function(){
 	var device = $('#div_advanceConfigForm').getValues('.deviceAttr')[0];


### PR DESCRIPTION
## Description
Change initTooltips to jeedomUtils.initTooltips


### Suggested changelog entry
Remove deprecated function 


### Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement
